### PR TITLE
Added bin and preferGlobal to package.json, fixes #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "type": "git",
     "url": "https://github.com/devgar/node-sink"
   },
+  "dependencies":{
+   
+  },
+  "preferGlobal" : true,
   "keywords": [
     "JSON",
     "search",
@@ -21,5 +25,9 @@
   "bugs": {
     "url": "https://github.com/devgar/node-sink/issues"
   },
-  "homepage": "https://github.com/devgar/node-sink"
+  
+  "homepage": "https://github.com/devgar/node-sink",
+  "bin" :{
+    "sink": "index.js"
+  }
 }


### PR DESCRIPTION
Now installing global with `npm install  . -g`
Enables to use `sink`
